### PR TITLE
Hash#reverse_merge! is not part of standard Ruby.  It's in ActiveSupport...

### DIFF
--- a/lib/graphicsmagick/image.rb
+++ b/lib/graphicsmagick/image.rb
@@ -62,7 +62,7 @@ module GraphicsMagick
     end
 
     def run command, opts={}
-    	opts.reverse_merge!(:timeout => 1.minute)
+    	opts = {:timeout => 1.minute}.merge(opts)
     	command = "gm #{command}"
     	cmd = Subexec.run(command, opts)
 


### PR DESCRIPTION
As per the title.
